### PR TITLE
Add Mock class for system class / Updated SPIController unit tests

### DIFF
--- a/app/app_tests/mocks/MockSysCalls.hpp
+++ b/app/app_tests/mocks/MockSysCalls.hpp
@@ -1,0 +1,44 @@
+#ifndef MOCKSYSCALLS_HPP
+#define MOCKSYSCALLS_HPP
+
+#include <fcntl.h>
+#include <gmock/gmock.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+class MockSysCalls
+{
+public:
+    static MockSysCalls &instance()
+    {
+        static MockSysCalls instance;
+        return instance;
+    }
+
+    MOCK_METHOD(int, open, (const char *path, int flags), ());
+    MOCK_METHOD(int, ioctl, (int fd, unsigned long request), ());
+    MOCK_METHOD(int, close, (int fd), ());
+
+private:
+    MockSysCalls() = default;
+    ~MockSysCalls() = default;
+    MockSysCalls(const MockSysCalls &) = delete;
+    MockSysCalls &operator=(const MockSysCalls &) = delete;
+};
+
+inline int mock_open(const char *path, int flags, ...)
+{
+    return MockSysCalls::instance().open(path, flags);
+}
+
+inline int mock_ioctl(int fd, unsigned long request, ...)
+{
+    return MockSysCalls::instance().ioctl(fd, request);
+}
+
+inline int mock_close(int fd)
+{
+    return MockSysCalls::instance().close(fd);
+}
+
+#endif // MOCKSYSCALLS_HPP

--- a/app/app_tests/unit/canbus/test_SPIController.cpp
+++ b/app/app_tests/unit/canbus/test_SPIController.cpp
@@ -1,6 +1,7 @@
-#include "MockSPIController.hpp"
-#include <gmock/gmock.h>
+#include "MockSysCalls.hpp"
+#include "SPIController.hpp"
 #include <gtest/gtest.h>
+#include <linux/spi/spidev.h>
 
 using ::testing::_;
 using ::testing::Return;
@@ -8,51 +9,80 @@ using ::testing::Return;
 class SPIControllerTest : public ::testing::Test
 {
 protected:
-    MockSPIController mockSPI;
+    SPIController *spiController;
+
+    void SetUp() override { spiController = new SPIController(mock_ioctl, mock_open, mock_close); }
+
+    void TearDown() override { delete spiController; }
 };
 
 TEST_F(SPIControllerTest, OpenDeviceSuccess)
 {
-    EXPECT_CALL(mockSPI, openDevice("/dev/spidev0.0")).WillOnce(Return(true));
-    ASSERT_TRUE(mockSPI.openDevice("/dev/spidev0.0"));
+    EXPECT_CALL(MockSysCalls::instance(), open(testing::StrEq("/dev/spidev0.0"), O_RDWR))
+        .WillOnce(Return(3));
+
+    ASSERT_NO_THROW(spiController->openDevice("/dev/spidev0.0"));
 }
 
 TEST_F(SPIControllerTest, OpenDeviceFailure)
 {
-    EXPECT_CALL(mockSPI, openDevice("/nonexistent-device/spidev0.0")).WillOnce(Return(false));
-    ASSERT_FALSE(mockSPI.openDevice("/nonexistent-device/spidev0.0"));
+    EXPECT_CALL(MockSysCalls::instance(), open(testing::StrEq("/dev/spidev0.0"), O_RDWR))
+        .WillOnce(Return(-1)); // Simulate failure
+
+    ASSERT_THROW(spiController->openDevice("/dev/spidev0.0"), std::runtime_error);
 }
 
 TEST_F(SPIControllerTest, ConfigureSPIValidParameters)
 {
-    EXPECT_CALL(mockSPI, configure(0, 8, 500000)).Times(1);
-    ASSERT_NO_THROW(mockSPI.configure(0, 8, 500000));
+    EXPECT_CALL(MockSysCalls::instance(), open(_, _)).WillOnce(Return(3));
+    spiController->openDevice("/dev/spidev0.0");
+
+    EXPECT_CALL(MockSysCalls::instance(), ioctl(_, SPI_IOC_WR_MODE)).WillOnce(Return(0));
+    EXPECT_CALL(MockSysCalls::instance(), ioctl(_, SPI_IOC_WR_BITS_PER_WORD)).WillOnce(Return(0));
+    EXPECT_CALL(MockSysCalls::instance(), ioctl(_, SPI_IOC_WR_MAX_SPEED_HZ)).WillOnce(Return(0));
+
+    ASSERT_NO_THROW(spiController->configure(0, 8, 500000));
 }
 
 TEST_F(SPIControllerTest, WriteByteSuccess)
 {
-    EXPECT_CALL(mockSPI, writeByte(0x01, 0xFF)).Times(1);
-    ASSERT_NO_THROW(mockSPI.writeByte(0x01, 0xFF));
+    EXPECT_CALL(MockSysCalls::instance(), open(_, _)).WillOnce(Return(3));
+    spiController->openDevice("/dev/spidev0.0");
+
+    EXPECT_CALL(MockSysCalls::instance(), ioctl(_, SPI_IOC_MESSAGE(1))).WillOnce(Return(0));
+
+    ASSERT_NO_THROW(spiController->writeByte(0x01, 0xFF));
 }
 
 TEST_F(SPIControllerTest, ReadByteSuccess)
 {
-    EXPECT_CALL(mockSPI, readByte(0x01)).WillOnce(Return(0xFF));
-    uint8_t value = mockSPI.readByte(0x01);
-    ASSERT_EQ(value, 0xFF);
+    EXPECT_CALL(MockSysCalls::instance(), open(_, _)).WillOnce(Return(3));
+    spiController->openDevice("/dev/spidev0.0");
+
+    EXPECT_CALL(MockSysCalls::instance(), ioctl(_, SPI_IOC_MESSAGE(1))).WillOnce(Return(0));
+
+    ASSERT_NO_THROW(spiController->readByte(0x01));
 }
 
 TEST_F(SPIControllerTest, SpiTransferSuccess)
 {
+    EXPECT_CALL(MockSysCalls::instance(), open(_, _)).WillOnce(Return(3));
+    spiController->openDevice("/dev/spidev0.0");
+
+    EXPECT_CALL(MockSysCalls::instance(), ioctl(_, SPI_IOC_MESSAGE(1))).WillOnce(Return(0));
+
     uint8_t tx[] = {0x02, 0x01, 0xFF};
     uint8_t rx[sizeof(tx)] = {0};
 
-    EXPECT_CALL(mockSPI, spiTransfer(tx, rx, sizeof(tx))).Times(1);
-    ASSERT_NO_THROW(mockSPI.spiTransfer(tx, rx, sizeof(tx)));
+    ASSERT_NO_THROW(spiController->spiTransfer(tx, rx, sizeof(tx)));
 }
 
 TEST_F(SPIControllerTest, CloseDeviceSuccess)
 {
-    EXPECT_CALL(mockSPI, closeDevice()).Times(1);
-    ASSERT_NO_THROW(mockSPI.closeDevice());
+    EXPECT_CALL(MockSysCalls::instance(), open(_, _)).WillOnce(Return(3));
+    spiController->openDevice("/dev/spidev0.0");
+
+    EXPECT_CALL(MockSysCalls::instance(), close(3)).WillOnce(Return(0));
+
+    ASSERT_NO_THROW(spiController->closeDevice());
 }

--- a/app/includes/canbus/CANMessageProcessor.hpp
+++ b/app/includes/canbus/CANMessageProcessor.hpp
@@ -12,36 +12,7 @@ public:
 
     CANMessageProcessor();
     ~CANMessageProcessor() = default;
-
-    /**
-     * Registers a message handler for a specific frame ID.
-     *
-     * This function associates a given frame ID with a message handler. If the provided
-     * handler is null, an exception is thrown to ensure that only valid handlers are registered.
-     * Otherwise, the handler is stored in the `handlers` map, allowing the system to process
-     * messages associated with the specified frame ID using the registered handler.
-     *
-     * @param frameID The ID of the message frame for which the handler is being registered.
-     * @param handler A function or callable object that will handle messages with the specified frame ID.
-     *
-     * @throws std::invalid_argument If the handler is null, indicating an invalid registration attempt.
-     */
     void registerHandler(uint16_t frameID, MessageHandler handler);
-
-    /**
-     * Processes a message by invoking the appropriate handler for the given frame ID.
-     *
-     * This function searches for a registered handler associated with the provided frame ID.
-     * If a handler is found, it is invoked with the provided message data. If no handler is
-     * registered for the frame ID, a runtime error is thrown, indicating that the message cannot
-     * be processed.
-     *
-     * @param frameID The ID of the message frame to be processed.
-     * @param data A vector containing the message data to be passed to the handler.
-     *
-     * @throws std::runtime_error If no handler is registered for the given frame ID,
-     *         preventing the message from being processed.
-     */
     void processMessage(uint16_t frameID, const std::vector<uint8_t>& data);
 
 private:

--- a/app/includes/canbus/CanBusManager.hpp
+++ b/app/includes/canbus/CanBusManager.hpp
@@ -9,67 +9,14 @@ class CanBusManager : public QObject
 {
     Q_OBJECT
 public:
-    /**
-     * Initializes the CanBusManager object by setting up the MCP2515Controller
-     * and connecting relevant signals and slots.
-     *
-     * @param spi_device A string representing the SPI device to initialize
-     *                   the MCP2515Controller with.
-     * @param parent A pointer to the parent QObject, typically used for object
-     *               hierarchy and memory management.
-     *
-     * This constructor creates a new MCP2515Controller instance using the provided
-     * SPI device and sets up connections between the controller and the CanBusManager
-     * to handle updates related to speed and RPM.
-     */
     explicit CanBusManager(const std::string &spi_device, QObject *parent = nullptr);
     CanBusManager(IMCP2515Controller *controller, QObject *parent = nullptr);
 
-    /**
-     * Destructor for the CanBusManager object.
-     *
-     * This destructor stops the reading process in the MCP2515Controller, disconnects
-     * the thread, and waits for the thread to finish before deleting the controller
-     * and thread objects.
-     */
     ~CanBusManager();
-
-    /**
-     * Initializes the CanBusManager by setting up and starting the MCP2515Controller
-     * in a separate thread.
-     *
-     * This function first attempts to initialize the MCP2515Controller. If initialization
-     * fails, it logs an error and returns false. If initialization is successful, it
-     * creates a new QThread for the controller, moves the controller to the new thread,
-     * and establishes necessary signal-slot connections to handle the reading process.
-     * The thread is started, allowing the controller to begin processing data in the background.
-     *
-     * @return Returns true if initialization and thread setup are successful, false
-     *         otherwise.
-     */
     bool initialize();
 
 signals:
-    /**
-     * Emits the `speedUpdated` signal with the updated speed value.
-     *
-     * This function is called when the speed value has been updated. It activates the `speedUpdated` signal
-     * with the updated speed value (`_t1`). The value is passed to the signal using the `QMetaObject::activate`
-     * method, which ensures that the connected slots are properly notified with the updated speed.
-     *
-     * @param _t1 The updated speed value to be emitted via the `speedUpdated` signal.
-     */
     void speedUpdated(float newSpeed);
-
-    /**
-     * Emits the `rpmUpdated` signal with the updated RPM value.
-     *
-     * This function is called when the RPM value has been updated. It activates the `rpmUpdated` signal
-     * with the updated RPM value (`_t1`). The value is passed to the signal using the `QMetaObject::activate`
-     * method, ensuring that the connected slots are notified with the updated RPM.
-     *
-     * @param _t1 The updated RPM value to be emitted via the `rpmUpdated` signal.
-     */
     void rpmUpdated(int newRpm);
 
 private:

--- a/app/includes/canbus/MCP2515Configurator.hpp
+++ b/app/includes/canbus/MCP2515Configurator.hpp
@@ -7,134 +7,20 @@
 
 class MCP2515Configurator {
 public:
-    /**
-     * Constructs an MCP2515Configurator object and initializes it with the provided SPI controller.
-     *
-     * This constructor takes an SPIController reference and associates it with the MCP2515Configurator,
-     * enabling the configurator to interact with the SPI hardware for configuring the MCP2515 controller.
-     * The SPIController is passed by reference, ensuring that the same controller is used throughout
-     * the configurator’s lifetime.
-     *
-     * @param spiController A reference to the SPIController object that will be used for communication
-     *                      with the MCP2515 controller.
-     */
     explicit MCP2515Configurator(ISPIController &spiController);
     ~MCP2515Configurator() = default;
 
-    /**
-     * Resets the MCP2515 chip and verifies that it has entered configuration mode.
-     *
-     * This function sends a reset command to the MCP2515 chip, then waits for a brief period
-     * to allow the reset process to complete. Afterward, it reads the chip's status register
-     * to ensure that the chip has entered the configuration mode, which is indicated by
-     * a specific value in the status register.
-     *
-     * @return Returns true if the chip has been successfully reset and is in configuration mode,
-     *         false otherwise.
-     */
     bool resetChip();
-
-    /**
-     * Configures the baud rate settings for the MCP2515 chip.
-     *
-     * This function sets the appropriate values for the baud rate prescaler and phase segments
-     * in the MCP2515 configuration registers (CNF1, CNF2, CNF3). These settings define the
-     * baud rate and timing characteristics for CAN communication. The values written to the
-     * registers are specific to a desired baud rate configuration.
-     */
     void configureBaudRate();
-
-    /**
-     * Configures the transmit (TX) buffer of the MCP2515 chip.
-     *
-     * This function clears the control register for the TX buffer (TXB0CTRL), effectively
-     * resetting the buffer's configuration to its default state. This step is part of
-     * setting up the MCP2515 for CAN message transmission.
-     *
-     * - TXB0CTRL: Transmit Buffer Control Register, which is cleared to ensure the
-     *              TX buffer is properly initialized before use.
-     */
     void configureTXBuffer();
-
-    /**
-     * Configures the receive (RX) buffer of the MCP2515 chip.
-     *
-     * This function sets the RX buffer control register (RXB0CTRL) to enable rollover and
-     * configures the buffer to receive all CAN messages. By setting these bits, the MCP2515
-     * will continuously store received messages, allowing for easier message processing.
-     *
-     * - RXB0CTRL: Receive Buffer Control Register, which is configured to enable rollover
-     *              and set the RX mode to receive all messages.
-     */
     void configureRXBuffer();
-
-    /**
-     * Configures the filters and masks for the MCP2515 chip.
-     *
-     * This function sets the values for the first filter and mask registers to allow the
-     * MCP2515 to filter incoming CAN messages based on specific criteria. The filter and mask
-     * settings determine which messages are passed to the RX buffer for processing.
-     *
-     * - Filter 0: The filter register is set to 0xFF, configuring the chip to accept specific
-     *             messages based on the filter settings.
-     * - Mask 0: The mask register is set to 0xFF, defining the acceptance criteria for the messages.
-     */
     void configureFiltersAndMasks();
-
-    /**
-     * Configures the interrupt settings for the MCP2515 chip.
-     *
-     * This function enables the receive interrupt by setting the appropriate bit in the
-     * CANINTE register. With this configuration, the MCP2515 will generate an interrupt
-     * whenever a message is received, allowing the system to handle incoming messages
-     * efficiently.
-     *
-     * - CANINTE: Interrupt Enable Register, where the receive interrupt bit is set to enable
-     *            interrupts for received messages.
-     */
     void configureInterrupts();
-
-    /**
-     * Sets the operation mode of the MCP2515 chip.
-     *
-     * This function writes the specified mode to the CANCTRL register, configuring the MCP2515
-     * to operate in the desired mode. The mode can be used to select different operation modes
-     * such as Normal, Sleep, or Configuration mode, based on the value provided.
-     *
-     * - CANCTRL: Control Register, where the mode is written to configure the chip's operation.
-     * @param mode The mode to set for the MCP2515, passed as a byte value corresponding to
-     *             the desired operation mode.
-     */
     void setMode(uint8_t mode);
 
-    /**
-     * Verifies if the MCP2515 is operating in the expected mode.
-     *
-     * This function reads the CANSTAT register and checks the mode bits to ensure that the
-     * MCP2515 is in the expected operation mode. The mode is verified by comparing the
-     * current mode with the provided expected mode.
-     *
-     * - CANSTAT: Status Register, where the current operation mode is read.
-     *
-     * @param expectedMode The expected mode value to compare against the current mode.
-     * @return Returns true if the current mode matches the expected mode, false otherwise.
-     */
     bool verifyMode(uint8_t expectedMode);
+    std::vector<uint8_t> readCANMessage(uint16_t &frameID);
 
-    /**
-     * Reads a CAN message from the MCP2515 chip.
-     *
-     * This function checks if a CAN message is available in the RX buffer. If data is available,
-     * it reads the frame ID and the message length, followed by the message data itself. The
-     * received data is stored in a vector and returned. After reading the message, the interrupt
-     * flag is cleared to allow further message processing.
-     *
-     * @param frameID A reference to a variable where the frame ID of the received message
-     *                will be stored.
-     * @return A vector containing the received CAN message data.
-     */
-	std::vector<uint8_t> readCANMessage(uint16_t& frameID);
-  
     static constexpr uint8_t RESET_CMD = 0xC0;
     static constexpr uint8_t CANCTRL = 0x0F;
     static constexpr uint8_t CANSTAT = 0x0E;
@@ -151,39 +37,8 @@ public:
 private:
     ISPIController &spiController;
 
-    /**
-     * Writes a value to a specified register on the MCP2515 chip.
-     *
-     * This function sends a write command to the specified register address and writes the
-     * given value to it via the SPI interface. It uses the SPIController to send the data
-     * to the MCP2515 chip.
-     *
-     * @param address The register address where the value will be written.
-     * @param value The value to write to the register.
-     */
     void writeRegister(uint8_t address, uint8_t value);
-
-    /**
-     * Reads a value from a specified register on the MCP2515 chip.
-     *
-     * This function sends a read command to the specified register address and retrieves
-     * the value stored in that register via the SPI interface. It uses the SPIController
-     * to read the data from the MCP2515 chip.
-     *
-     * @param address The register address to read from.
-     * @return The value stored in the specified register.
-     */
     uint8_t readRegister(uint8_t address);
-
-    /**
-     * Sends a command to the MCP2515 chip via SPI.
-     *
-     * This function sends a single command byte to the MCP2515 chip using the SPI interface.
-     * The command is transmitted via the `spiTransfer` function of the SPIController, and
-     * no data is expected to be received in response.
-     *
-     * @param command The command byte to send to the MCP2515 chip.
-     */
     void sendCommand(uint8_t command);
 
 };

--- a/app/includes/canbus/MCP2515Controller.hpp
+++ b/app/includes/canbus/MCP2515Controller.hpp
@@ -12,68 +12,16 @@ class MCP2515Controller : public IMCP2515Controller
 {
     Q_OBJECT
 public:
-    /**
-     * Constructs an MCP2515Controller object and initializes the SPI interface and related components.
-     *
-     * This constructor initializes the SPI controller and the associated configurator and message
-     * processor objects. It attempts to open the SPI device using the provided device path. If
-     * opening the device fails, an exception is thrown. After the device is successfully opened,
-     * the constructor sets up the message handlers to handle incoming CAN messages.
-     *
-     * @param spiDevice The path to the SPI device to initialize the SPIController with.
-     *
-     * @throws std::runtime_error If the SPI device cannot be opened, indicating a failure in
-     *         device initialization.
-     */
     explicit MCP2515Controller(const std::string &spiDevice);
-    
     MCP2515Controller(const std::string &spiDevice, ISPIController &spiController);
 
-    /**
-     * Destroys the MCP2515Controller object and cleans up resources.
-     *
-     * This destructor closes the SPI device to release the associated resources. It ensures
-     * proper cleanup of the SPI connection when the MCP2515Controller object is destroyed.
-     */
     ~MCP2515Controller() override;
 
-    /**
-     * Initializes the MCP2515 chip and configures it for normal operation.
-     *
-     * This function resets the MCP2515 chip and configures various parameters, including baud rate,
-     * transmit and receive buffers, filters, masks, and interrupts. It then sets the chip to normal mode.
-     * If any step fails, an exception is thrown to indicate the failure.
-     *
-     * @return Returns true if the initialization is successful and the chip is set to normal mode.
-     *
-     * @throws std::runtime_error If any initialization step fails, such as resetting the chip or setting it
-     *         to normal mode, indicating a failure in the initialization process.
-     */
     bool init() override;
-
-    /**
-     * Continuously reads CAN messages from the MCP2515 chip and processes them.
-     *
-     * This function enters a loop that reads CAN messages from the MCP2515 chip and processes them
-     * using the message processor. It will continue reading and processing messages until the
-     * `stopReadingFlag` is set to true. If an error occurs while processing a message, an error
-     * message is logged. The function sleeps for 10 milliseconds between each iteration to manage
-     * processing time.
-     *
-     * @throws std::exception If an error occurs during message reading or processing,
-     *         an exception will be caught and logged.
-     */
     void processReading() override;
-
-    /**
-     * Stops the CAN message reading loop.
-     *
-     * This function sets the `stopReadingFlag` to true, which causes the reading loop in
-     * `processReading` to exit, stopping the continuous reading and processing of CAN messages.
-     */
     void stopReading() override;
-    
-      CANMessageProcessor &getMessageProcessor() { return messageProcessor; }
+
+    CANMessageProcessor &getMessageProcessor() { return messageProcessor; }
     bool isStopReadingFlagSet() const override;
 
 signals:
@@ -87,17 +35,6 @@ private:
     bool stopReadingFlag = false;
     bool ownsSPIController = false;
 
-    /**
-     * Sets up message handlers for processing specific CAN frame IDs.
-     *
-     * This function registers custom handlers for specific CAN frame IDs. Each handler processes
-     * the corresponding CAN message data and emits signals for relevant values such as speed or RPM.
-     * The handlers are registered with the message processor, which is responsible for processing
-     * incoming messages and invoking the appropriate handler based on the frame ID.
-     *
-     * - Frame ID 0x100: Extracts a float representing speed (scaled by 10) and emits the `speedUpdated` signal.
-     * - Frame ID 0x200: Extracts a 16-bit value representing RPM and emits the `rpmUpdated` signal.
-     */
     void setupHandlers();
 };
 

--- a/app/includes/canbus/SPIController.hpp
+++ b/app/includes/canbus/SPIController.hpp
@@ -3,111 +3,30 @@
 
 #include "ISPIController.hpp"
 #include <cstdint>
+#include <fcntl.h>
 #include <string>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+using IoctlFunc = int (*)(int, unsigned long, ...);
+using OpenFunc = int (*)(const char *, int, ...);
+using CloseFunc = int (*)(int);
 
 class SPIController : public ISPIController
 {
 public:
     enum class Opcode : uint8_t { Write = 0x02, Read = 0x03 };
 
-    /**
-     * Constructs an SPIController object and initializes default settings.
-     *
-     * This constructor initializes the SPIController with default values for the SPI file descriptor,
-     * mode, bits per word, and speed. The `spi_fd` is set to -1 to indicate that the device is not
-     * yet opened. Default settings are used for the mode, bits per word, and speed until they are
-     * explicitly configured.
-     */
-    SPIController();
-
-    /**
-     * Destroys the SPIController object and cleans up resources.
-     *
-     * This destructor calls the `closeDevice` function to ensure that the SPI device is properly closed
-     * and any resources associated with the SPI connection are released when the SPIController object is destroyed.
-     */
+    SPIController(IoctlFunc ioctlFunc = ::ioctl,
+                  OpenFunc openFunc = ::open,
+                  CloseFunc closeFunc = ::close);
     ~SPIController() override;
 
-    /**
-     * Opens the specified SPI device for communication.
-     *
-     * This function attempts to open the SPI device specified by the `device` string. If the device
-     * cannot be opened, it throws an exception with an error message. If the device is successfully
-     * opened, it returns true. The `spi_fd` file descriptor is set to the opened device's file descriptor.
-     *
-     * @param device The path to the SPI device to open.
-     * @return Returns true if the device is successfully opened.
-     *
-     * @throws std::runtime_error If the device cannot be opened, indicating a failure in the SPI device
-     *         initialization.
-     */
     bool openDevice(const std::string &device) override;
-
-    /**
-     * Configures the SPI interface with the specified settings.
-     *
-     * This function configures the SPI device with the provided mode, bits per word, and speed.
-     * It checks if the device is open and throws an exception if the device is not open. The function
-     * then applies the configuration settings using the appropriate `ioctl` system calls. If any configuration
-     * step fails, an exception is thrown with an error message.
-     *
-     * @param mode The SPI mode to set for the communication.
-     * @param bits The number of bits per word for SPI communication.
-     * @param speed The SPI clock speed (in Hz).
-     *
-     * @throws std::runtime_error If the device is not open or if any configuration step fails
-     *         (setting the mode, bits per word, or speed).
-     */
     void configure(uint8_t mode, uint8_t bits, uint32_t speed) override;
-
-    /**
-     * Writes a byte of data to the specified address on the SPI device.
-     *
-     * This function sends a write command to the SPI device, using the specified address and data byte.
-     * The command is formed by combining the write opcode, the address, and the data byte. The SPI transfer
-     * is then performed using the `spiTransfer` function to send the data to the device.
-     *
-     * @param address The address to write the data to on the SPI device.
-     * @param data The data byte to write to the specified address.
-     */
     void writeByte(uint8_t address, uint8_t data) override;
-
-    /**
-     * Reads a byte of data from the specified address on the SPI device.
-     *
-     * This function sends a read command to the SPI device, using the specified address. The function
-     * performs a SPI transfer, where the read command is sent along with the address. The data byte
-     * returned from the SPI device is stored in the response buffer and returned by the function.
-     *
-     * @param address The address to read the data from on the SPI device.
-     * @return The data byte read from the specified address.
-     */
     uint8_t readByte(uint8_t address) override;
-
-    /**
-     * Performs an SPI transfer, sending and receiving data.
-     *
-     * This function transfers data to and from the SPI device. It sends the specified `tx` (transmit)
-     * buffer and receives data into the `rx` (receive) buffer. The function uses the `ioctl` system
-     * call with the `SPI_IOC_MESSAGE` command to initiate the transfer. If the device is not open or
-     * the transfer fails, an exception is thrown.
-     *
-     * @param tx A pointer to the transmit buffer containing the data to send to the SPI device.
-     * @param rx A pointer to the receive buffer where data read from the SPI device will be stored.
-     * @param length The length of the data to transfer (in bytes).
-     *
-     * @throws std::runtime_error If the SPI device is not open or if the transfer fails, indicating
-     *         an error during the SPI communication.
-     */
     void spiTransfer(const uint8_t *tx, uint8_t *rx, size_t length) override;
-
-    /**
-     * Closes the SPI device and releases the associated resources.
-     *
-     * This function closes the SPI device by calling the `close` system call on the SPI file descriptor
-     * (`spi_fd`). It sets `spi_fd` to -1 to indicate that the device has been closed. If the device is
-     * already closed (i.e., `spi_fd` is negative), the function does nothing.
-     */
     void closeDevice() override;
 
 private:
@@ -115,6 +34,10 @@ private:
     uint8_t mode;
     uint8_t bits;
     uint32_t speed;
+
+    IoctlFunc m_ioctlFunc;
+    OpenFunc m_openFunc;
+    CloseFunc m_closeFunc;
 
     static constexpr uint8_t DefaultBitsPerWord = 8;
     static constexpr uint32_t DefaultSpeedHz = 1'000'000;


### PR DESCRIPTION
Now SPIController tests rely on a mock system calls class with mocked open, close and ioctl functions